### PR TITLE
Fix syntax and semantic errors in spatial-addon.avsc

### DIFF
--- a/fermi.gbm.ground_pos-value.avsc
+++ b/fermi.gbm.ground_pos-value.avsc
@@ -1,7 +1,6 @@
 {
 	"type": "record",
 	"name":"Fermi GBM Ground Position",
-	"namespace": "fermi.gbm.ground_pos",
 	"fields": [
 		{"name": "trigger_num", "type": "int", "doc": "Fermi trigger number"},
 		{"name": "data_signif", "type": "float", "doc": "significance (sigma)"},
@@ -10,8 +9,8 @@
 		{"name":"energy-low","type":"float", "doc": "lower bound energy range of trigger (keV)"},
 		{"name":"energy-high","type":"float", "doc": "upper bound energy range of trigger (keV)"},
 		{"name":"loc_algorithm", "type": "int", "doc": "(Gnd S/W Version number)"},
-		{"name":"time","type":"time"},
+		{"name":"time","type":"float"},
 		{"name":"spatial","type":"spatial-value"},
-		{"name":"spatial-addon","type":"spatial_addon"}
+		{"name":"spatial-addon","type":"spatial-addon"}
 	]
 }

--- a/spatial-addon.avsc
+++ b/spatial-addon.avsc
@@ -2,48 +2,53 @@
 	"type": "record",
 	"name": "spatial-addon",
 	"fields": [
-		{"name": "sun",
-			"type":{
-				"type":"array",
-				"items":{
-					"name":"sun-ra","type":"float", "doc": "right ascension of sun (deg)",
-					"name":"sun-dec","type":"float", "doc": "declination of sun (deg)",
-					"name":"sun-dist","type":"float", "doc": "angular distance between sun and source (deg)",
-					"name":"sun-hourangle","type":"float", "doc": "hour angle between sun and source (hours)"
-				}
+		{
+			"name": "sun",
+			"type": {
+				"type": "record",
+				"name": "Sun",
+				"fields": [
+					{"name": "ra", "type": "float", "doc": "right ascension of sun (deg)"},
+					{"name": "dec", "type": "float", "doc": "declination of sun (deg)"},
+					{"name": "dist", "type": "float", "doc": "angular distance between sun and source (deg)"},
+					{"name": "hourangle", "type": "float", "doc": "hour angle between sun and source (hours)"}
+				]
+			}
+		},
+		{
+			"name": "moon",
+			"type": {
+				"type": "record",
+				"name": "Moon",
+				"fields": [
+					{"name": "ra", "type": "float", "doc": "right ascension of moon (deg)"},
+					{"name": "dec", "type": "float", "doc": "declination of moon (deg)"},
+					{"name": "dist", "type": "float", "doc": "angular distance between moon and source (deg)"},
+					{"name": "illumination", "type": "float", "doc": "illumination of the moon (percent)"}
+				]
+			}
+		},
+		{
+			"name": "galactic",
+			"type": {
+				"type": "record",
+				"name": "Galactic",
+				"fields": [
+					{"name": "lon", "type": "float", "doc": "galactic longitude of source (deg)"},
+					{"name": "lat", "type": "float", "doc": "galactic latitude of source (deg)"}
+				]
+			}
+		},
+		{
+			"name": "ecliptic",
+			"type": {
+				"type": "record",
+				"name": "Ecliptic",
+				"fields": [
+					{"name": "lon", "type": "float", "doc": "ecliptic longitude of source (deg)"},
+					{"name": "lat", "type": "float", "doc": "ecliptic latitude of source (deg)"}
+				]
 			}
 		}
-		{"name": "moon",
-			"type":{
-				"type":"array",
-				"items":{
-					"name":"moon-ra","type":"float", "doc": "right ascension of moon (deg)",
-					"name":"moon-dec","type":"float", "doc": "declination of moon (deg)",
-					"name":"moon-dist","type":"float", "doc": "angular distance between moon and source (deg)",
-					"name":"moon-illumination","type":"float", "doc": "illumination of the moon (percent)"
-				}
-			}
-		}
-		{"name": "galactic-coords",
-			"type":{
-				"type":"array",
-				"items":{
-					"name":"galactic-long","type":"float", "doc": "galactic longitude of source (deg)",
-					"name":"galactic-lat","type":"float", "doc": "galactic latitude of source (deg)",
-				}
-			}
-		}
-		{"name": "ecliptic-coords",
-			"type":{
-				"type":"array",
-				"items":{
-					"name":"ecliptic-long","type":"float", "doc": "ecliptic longitude of source (deg)",
-					"name":"ecliptic-lat","type":"float", "doc": "ecliptic latitude of source (deg)",
-				}
-			}
-		}
-
-
-
 	]
 }

--- a/spatial-value.avsc
+++ b/spatial-value.avsc
@@ -4,10 +4,10 @@
   "fields": [
     {"name": "ra", "type": "double", "doc": "J2000 right ascension (degrees)"},
     {"name": "dec", "type": "double", "doc": "J2000 declination (degrees)"},
-    {"name": "error-1sig", "type": "double", "doc": "position error radius (1sig confidence, degrees)"}
-    {"name": "error90", "type": "double", "doc": "position error radius (90% confidence, degrees)"}
-    {"name": "error-2sig", "type": "double", "doc": "position error radius (2sig confidence, degrees)"}
-    {"name": "error-3sig", "type": "double", "doc": "position error radius (2sig confidence, degrees)"}
+    {"name": "error-1sig", "type": "double", "doc": "position error radius (1sig confidence, degrees)"},
+    {"name": "error90", "type": "double", "doc": "position error radius (90% confidence, degrees)"},
+    {"name": "error-2sig", "type": "double", "doc": "position error radius (2sig confidence, degrees)"},
+    {"name": "error-3sig", "type": "double", "doc": "position error radius (2sig confidence, degrees)"},
     {"name": "prob-map", 
       "type":{
         "type": "record", 


### PR DESCRIPTION
* Also, use `lon` instead of `long` to identify longitudes, because `long` is a reserved word in many programming languages.
* Also, rename fields like `sun.sun-ra` to `sun.ra`.
