### PR TITLE
FRB: Add subsequent field

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ npm install
 
         npm install
 
-3.  Tag a new version by running the following command: `npm version [ major | minor | patch ]`. Choose `major`, `minor`, or `patch` depending on the kind of update according to [Semantic Versioning](https://semver.org) rules. Updates are categorized as major, minor, or patch, depending on the type of change. A major change is defined as any modification that breaks compatibility with the core schema, such as a change in a property or the addition of a new property that affects the mission pipelines. Introducing a new mission and new core schema constitutes a minor change, while modifying the new mission schema and adding a new property to the core schema are considered patches.
+3.  3.  Tag a new version by running the following command: `npm version [ major | minor | patch ]`. Choose `major`, `minor`, or `patch` depending on the kind of update according to [Semantic Versioning](https://semver.org) rules.
 
-        This command will handle the intermediate steps of updating and committing the path changes in each file as defined in the `version` and `postversion` npm scripts.
+    This command will handle the intermediate steps of updating and committing the path changes in each file as defined in the `version` and `postversion` npm scripts
 
 4.  Review the changes with `git log -p` to make sure that each file is appropriately updated.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install
 
         npm install
 
-3.  3.  Tag a new version by running the following command: `npm version [ major | minor | patch ]`. Choose `major`, `minor`, or `patch` depending on the kind of update according to [Semantic Versioning](https://semver.org) rules.
+3.  Tag a new version by running the following command: `npm version [ major | minor | patch ]`. Choose `major`, `minor`, or `patch` depending on the kind of update according to [Semantic Versioning](https://semver.org) rules.
 
     This command will handle the intermediate steps of updating and committing the path changes in each file as defined in the `version` and `postversion` npm scripts
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ npm install
 
         npm install
 
-3.  Tag a new version by running the following command: `npm version [ major | minor | patch ]`. Choose `major`, `minor`, or `patch` depending on the kind of update according to [Semantic Versioning](https://semver.org) rules.
+3.  Tag a new version by running the following command: `npm version [ major | minor | patch ]`. Choose `major`, `minor`, or `patch` depending on the kind of update according to [Semantic Versioning](https://semver.org) rules. Updates are categorized as major, minor, or patch, depending on the type of change. A major change is defined as any modification that breaks compatibility with the core schema, such as a change in a property or the addition of a new property that affects the mission pipelines. Introducing a new mission and new core schema constitutes a minor change, while modifying the new mission schema and adding a new property to the core schema are considered patches.
 
-    This command will handle the intermediate steps of updating and committing the path changes in each file as defined in the `version` and `postversion` npm scripts
+        This command will handle the intermediate steps of updating and committing the path changes in each file as defined in the `version` and `postversion` npm scripts.
 
 4.  Review the changes with `git log -p` to make sure that each file is appropriately updated.
 

--- a/gcn/notices/core/Alert.schema.json
+++ b/gcn/notices/core/Alert.schema.json
@@ -21,8 +21,8 @@
       "description": "Indication of whether this alert refers to a recent observation (current), re-analysis of archival data (archival), a planned observation in the future (planned), a signal injection (injection), commanded trigger (commanded) or a test trigger (test)."
     },
     "alert_type": {
-      "enum": ["initial", "update", "retraction"],
-      "description": "Indication of alert sequence if multiple of same type sent"
+      "enum": ["initial", "subsequent", "update", "retraction"],
+      "description": "Indication of alert sequence if multiple of the same type are sent. Alert sequence: initial refers to the detection, followed by subsequent alerts for recurrent observations from the same source. Updates and retractions come from further analysis."
     }
   }
 }

--- a/gcn/notices/core/Alert.schema.json
+++ b/gcn/notices/core/Alert.schema.json
@@ -21,8 +21,8 @@
       "description": "Indication of whether this alert refers to a recent observation (current), re-analysis of archival data (archival), a planned observation in the future (planned), a signal injection (injection), commanded trigger (commanded) or a test trigger (test)."
     },
     "alert_type": {
-      "enum": ["initial", "subsequent", "update", "retraction"],
-      "description": "Indication of alert sequence if multiple of the same type are sent. Alert sequence: initial refers to the detection, followed by subsequent alerts for recurrent observations from the same source. Updates and retractions come from further analysis."
+      "enum": ["initial", "update", "retraction"],
+      "description": "Indication of alert sequence if multiple of the same type are sent."
     }
   }
 }

--- a/gcn/notices/core/Alert.schema.json
+++ b/gcn/notices/core/Alert.schema.json
@@ -21,8 +21,8 @@
       "description": "Indication of whether this alert refers to a recent observation (current), re-analysis of archival data (archival), a planned observation in the future (planned), a signal injection (injection), commanded trigger (commanded) or a test trigger (test)."
     },
     "alert_type": {
-      "enum": ["initial", "update", "retraction"],
-      "description": "Indication of alert sequence if multiple of the same type are sent."
+      "enum": ["initial", "subsequent", "update", "retraction"],
+      "description": "Indication of alert sequence if multiple of the same type are sent. Alert sequence: initial refers to the detection, followed by subsequent alerts for recurrent detections of the same source. Updates and retractions come from further analysis."
     }
   }
 }

--- a/gcn/notices/core/DateTime.schema.json
+++ b/gcn/notices/core/DateTime.schema.json
@@ -9,6 +9,12 @@
       "type": "string",
       "description": "Time of the trigger [ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ"
     },
+    "trigger_time_error": {
+      "type": "array",
+      "items": { "type": "number" },
+      "maxItems": 2,
+      "description": "Trigger time uncertainty [s, 1-sigma], with optional asymmetric uncertainty"
+    },
     "observation_start": {
       "type": "string",
       "description": "Start time of the observation [ISO 8601]"


### PR DESCRIPTION
# Description
As FRBs may have reoccurent observation from the same source but in late times.
Following CHIME, adding "subsequent" in our alert_type core schema.

I have a question: is "initial" ok or "detection" word is better instead?


Resolves #https://github.com/nasa-gcn/gcn-schema/issues/198


