### PR TITLE
Expanding Core Schema for FRB

### DIFF
--- a/gcn/notices/core/DispersionMeasure.schema.json
+++ b/gcn/notices/core/DispersionMeasure.schema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/DispersionMeasure.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "Schema for Radio Transients Observables",
+  "description": "Dispersion Measure schema used for radio transients",
+  "properties": {
+    "dm": {
+      "type": "number",
+      "description": "Dispersion measure (DM) of the burst [pc/cm^3], representing the integrated column density of free electrons along the line of sight."
+    },
+    "dm_error": {
+      "type": "array",
+      "items": { "type": "number" },
+      "maxItems": 2,
+      "description": "Uncertainity associated with the dispersion measure [pc/cm^3, 1-sigma], with optional asymmetric uncertainty."
+    }
+  }
+}

--- a/gcn/notices/core/Reporter.schema.json
+++ b/gcn/notices/core/Reporter.schema.json
@@ -21,10 +21,23 @@
       "enum": ["EM", "GW", "Neutrino"],
       "description": "Messenger of report; EM, GW or Neutrino"
     },
+    "spectral_band": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "description": "Observed spectral band, must be consistent with the 'spectrum' type and expressed in the specified 'units' field",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "spectral_center": {
+      "type": "number",
+      "description": "Central value of the observed spectral band, must be consistent with the 'spectrum' type and expressed in the specified 'units' field"
+    },
     "units": {
-      "enum": ["keV", "nm", "Hz"],
-      "description": "Units of band range, if not parsed, then default energy is keV",
       "type": "string",
+      "enum": ["keV", "nm", "Hz"],
+      "description": "Units for the spectral data; default unit is keV",
       "default": "keV"
     },
     "filter": {


### PR DESCRIPTION
# Description
Observables relevant for radio transients:

- Dispersion Measure schema

- Reporter.schema.json: `spectral_center`

- DateTime.schema.json: `time_resolution`

