### PR TITLE
Core Schema: Notice_type

### DIFF
--- a/gcn/notices/core/Reporter.schema.json
+++ b/gcn/notices/core/Reporter.schema.json
@@ -13,6 +13,10 @@
       "type": "string",
       "description": "Name of the Instrument reporting the event"
     },
+    "notice_type": {
+      "type": "string",
+      "description": "Defines the category or type of notice and serves as its title. It is recommended when a single schema is used to produce multiple notice types."
+    },
     "record_number": {
       "type": "number",
       "description": "Incremental number for messages from the instrument during a given trigger (ex: 1, 2, 3)"


### PR DESCRIPTION
# Description

Single schema is requested to handle multiple notice types from the mission teams. 

While the notice types are distinct in the example files, in the streaming process, all notices are generated from the same pipeline.
This property is useful to distinct the types of notices. 

Also, 'notice_type' is consistent with GCN Classic Notices.