### PR TITLE
Add templates folder and sample schema

### DIFF
--- a/gcn/notices/templates/sample.example.json
+++ b/gcn/notices/templates/sample.example.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://gcn.nasa.gov/schema/main/gcn/notices/templates/sample.schema.json",
+  "alert_datetime": "2023-09-28T01:40:30Z",
+  "ra": 197.44871198,
+  "dec": -23.38397612,
+  "example_field_1": "The ultimate answer to life, the universe, and everything",
+  "example_field_2": 42
+}

--- a/gcn/notices/templates/sample.schema.json
+++ b/gcn/notices/templates/sample.schema.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/templates/sample.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "title": "Your Schema Name",
+  "description": "A description for your schema",
+  "allOf": [
+    {
+      "$ref": "../core/Alert.schema.json"
+    },
+    {
+      "$ref": "../core/Localization.schema.json"
+    }
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "example_field_1": {
+      "type": "string",
+      "description": "A custom field that can hold text"
+    },
+    "example_field_2": {
+      "type": "number",
+      "description": "A custom field that holds a number"
+    }
+  }
+}


### PR DESCRIPTION
# Description
Template folder for hosting common GCN alert schema, 
which can be utilized by similar type of observatories example neutrino observations. 

Also, contains a sample schema and example for what schema should contain.

# Related Issue(s)
PR #236 