### PR TITLE
Uncertainty property upgrade

### DIFF
--- a/gcn/notices/core/DateTime.schema.json
+++ b/gcn/notices/core/DateTime.schema.json
@@ -10,7 +10,7 @@
       "description": "Time of the trigger [ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ"
     },
     "trigger_time_error": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number",
           "description": "Trigger time uncertainty [s, 1-sigma], with symmetric uncertainty"

--- a/gcn/notices/core/DateTime.schema.json
+++ b/gcn/notices/core/DateTime.schema.json
@@ -10,10 +10,18 @@
       "description": "Time of the trigger [ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ"
     },
     "trigger_time_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "Trigger time uncertainty [s, 1-sigma], with optional asymmetric uncertainty"
+      "anyOf": [
+        {
+          "type": "number",
+          "description": "Trigger time uncertainty [s, 1-sigma], with symmetric uncertainty"
+        },
+        {
+          "type": "array",
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "description": "Trigger time uncertainty [s, 1-sigma], with asymmetric uncertainty"
+        }
+      ]
     },
     "observation_start": {
       "type": "string",

--- a/gcn/notices/core/DispersionMeasure.schema.json
+++ b/gcn/notices/core/DispersionMeasure.schema.json
@@ -10,10 +10,18 @@
       "description": "Dispersion measure (DM) of the burst [pc/cm^3], representing the integrated column density of free electrons along the line of sight."
     },
     "dm_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "Uncertainity associated with the dispersion measure [pc/cm^3, 1-sigma], with optional asymmetric uncertainty."
+      "anyOf": [
+        {
+          "type": "number",
+          "description": "Uncertainity associated with the dispersion measure [pc/cm^3, 1-sigma], with symmetric uncertainty"
+        },
+        {
+          "type": "array",
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "description": "Uncertainity associated with the dispersion measure [pc/cm^3, 1-sigma], with asymmetric uncertainty"
+        }
+      ]
     }
   }
 }

--- a/gcn/notices/core/DispersionMeasure.schema.json
+++ b/gcn/notices/core/DispersionMeasure.schema.json
@@ -10,7 +10,7 @@
       "description": "Dispersion measure (DM) of the burst [pc/cm^3], representing the integrated column density of free electrons along the line of sight."
     },
     "dm_error": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number",
           "description": "Uncertainity associated with the dispersion measure [pc/cm^3, 1-sigma], with symmetric uncertainty"

--- a/gcn/notices/core/Distance.schema.json
+++ b/gcn/notices/core/Distance.schema.json
@@ -10,10 +10,18 @@
       "description": "Luminosity distance [Mpc]"
     },
     "luminosity_distance_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "Luminosity distance uncertainty [Mpc, 1-sigma], with optional asymmetric uncertainty"
+      "anyOf": [
+        {
+          "type": "number",
+          "description": "Luminosity distance uncertainty [Mpc, 1-sigma], with symmetric uncertainty"
+        },
+        {
+          "type": "array",
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "description": "Luminosity distance uncertainty [Mpc, 1-sigma], with optional asymmetric uncertainty"
+        }
+      ]
     }
   }
 }

--- a/gcn/notices/core/Distance.schema.json
+++ b/gcn/notices/core/Distance.schema.json
@@ -10,7 +10,7 @@
       "description": "Luminosity distance [Mpc]"
     },
     "luminosity_distance_error": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number",
           "description": "Luminosity distance uncertainty [Mpc, 1-sigma], with symmetric uncertainty"

--- a/gcn/notices/core/Duration.schema.json
+++ b/gcn/notices/core/Duration.schema.json
@@ -27,7 +27,7 @@
       "description": "Time duration of central 50% of integrated fluence [s]"
     },
     "t50_error": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number",
           "description": "1-sigma uncertainty of the T50 duration [s], with symmetric statistical errors taken into account"

--- a/gcn/notices/core/Duration.schema.json
+++ b/gcn/notices/core/Duration.schema.json
@@ -9,20 +9,36 @@
       "description": "Time duration of central 90% of integrated fluence [s]"
     },
     "t90_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "1-sigma uncertainty of the T90 duration [s], with asymmetric statistical errors taken into account"
+      "anyOf": [
+        {
+          "type": "number",
+          "description": "1-sigma uncertainty of the T90 duration [s], with symmetric statistical errors taken into account"
+        },
+        {
+          "type": "array",
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "description": "1-sigma uncertainty of the T90 duration [s], with asymmetric statistical errors taken into account"
+        }
+      ]
     },
     "t50": {
       "type": "number",
       "description": "Time duration of central 50% of integrated fluence [s]"
     },
     "t50_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "1-sigma uncertainty of the T50 duration [s], with asymmetric statistical errors taken into account"
+      "anyOf": [
+        {
+          "type": "number",
+          "description": "1-sigma uncertainty of the T50 duration [s], with symmetric statistical errors taken into account"
+        },
+        {
+          "type": "array",
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "description": "1-sigma uncertainty of the T50 duration [s], with asymmetric statistical errors taken into account"
+        }
+      ]
     }
   }
 }

--- a/gcn/notices/core/Duration.schema.json
+++ b/gcn/notices/core/Duration.schema.json
@@ -9,7 +9,7 @@
       "description": "Time duration of central 90% of integrated fluence [s]"
     },
     "t90_error": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number",
           "description": "1-sigma uncertainty of the T90 duration [s], with symmetric statistical errors taken into account"

--- a/gcn/notices/core/HardnessRatio.schema.json
+++ b/gcn/notices/core/HardnessRatio.schema.json
@@ -10,7 +10,7 @@
       "description": "Ratio of flux between high and low energy bands"
     },
     "hardness_ratio_error": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number",
           "description": "Error in hardness ratio, number for symmetric statistical error"

--- a/gcn/notices/core/HardnessRatio.schema.json
+++ b/gcn/notices/core/HardnessRatio.schema.json
@@ -7,13 +7,21 @@
   "properties": {
     "hardness_ratio": {
       "type": "number",
-      "description": "ratio of flux between high and low energy bands"
+      "description": "Ratio of flux between high and low energy bands"
     },
     "hardness_ratio_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "ratio of flux between high and low energy bands, with asymmetric statistical errors taken into account"
+      "anyOf": [
+        {
+          "type": "number",
+          "description": "Error in hardness ratio, number for symmetric statistical error"
+        },
+        {
+          "type": "array",
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "description": "Error in hardness ratio, array for asymmetric statistical errors"
+        }
+      ]
     },
     "energy_range_soft": {
       "type": "array",

--- a/gcn/notices/core/Redshift.schema.json
+++ b/gcn/notices/core/Redshift.schema.json
@@ -10,10 +10,18 @@
       "description": "Displacement of spectral lines toward longer wavelengths [sigma]"
     },
     "redshift_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "Error in redshift, array for asymmetric statistical errors"
+      "anyOf": [
+        {
+          "type": "number",
+          "description": "Error in redshift, number for symmetric statistical error"
+        },
+        {
+          "type": "array",
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "description": "Error in redshift, array for asymmetric statistical errors"
+        }
+      ]
     },
     "redshift_measure": { "enum": ["spectroscopic", "photometric"] },
     "redshift_type": { "enum": ["emission", "absorption", "host"] }

--- a/gcn/notices/core/Redshift.schema.json
+++ b/gcn/notices/core/Redshift.schema.json
@@ -10,7 +10,7 @@
       "description": "Displacement of spectral lines toward longer wavelengths [sigma]"
     },
     "redshift_error": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number",
           "description": "Error in redshift, number for symmetric statistical error"


### PR DESCRIPTION
# Description
Uncertainty can be either symmetric or asymmetric. 
Thus, schema should accept both an array and a number.

All existing uncertainities are array, except `ra_dec_error`. 
As part of an upgrade, all errors in the core schema are redefined to be compatible with both number and array.

If any mission pipeline is using array for even symmetric, it will continue the function w/t breaking the pipeline.
It should accept: 1, [1], [-1, 1]



