### PR TITLE
Event Name: Fixing for single or array types

### DIFF
--- a/gcn/notices/core/Event.schema.json
+++ b/gcn/notices/core/Event.schema.json
@@ -6,9 +6,17 @@
   "description": "Name or names of the event",
   "properties": {
     "event_name": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Name of the event (ex: GRB 170817A, GW170817, AT2017gfo, SSS 17a)"
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Name of the event (ex: GRB 170817A, GW170817, AT2017gfo, SSS 17a)"
+        },
+        {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "If multiple event names are present"
+        }
+      ]
     },
     "id": {
       "oneOf": [

--- a/gcn/notices/core/Event.schema.json
+++ b/gcn/notices/core/Event.schema.json
@@ -14,7 +14,7 @@
         {
           "type": "array",
           "items": { "type": "string" },
-          "description": "If multiple event names are present"
+          "description": "Multiple names of the same event (ex: GRB 170817A, GW170817, AT2017gfo, SSS 17a)"
         }
       ]
     },

--- a/gcn/notices/core/Event.schema.json
+++ b/gcn/notices/core/Event.schema.json
@@ -9,7 +9,7 @@
       "oneOf": [
         {
           "type": "string",
-          "description": "Name of the event (ex: GRB 170817A, GW170817, AT2017gfo, SSS 17a)"
+          "description": "Name of the event (ex: GRB 170817A)"
         },
         {
           "type": "array",


### PR DESCRIPTION
# Description

For single event name array isn't must.
This fix allows both single string or array.