### PR TITLE
Rename spectrum units to be self-explantory

### DIFF
--- a/gcn/notices/core/Reporter.schema.json
+++ b/gcn/notices/core/Reporter.schema.json
@@ -28,7 +28,7 @@
       "minItems": 2,
       "maxItems": 2
     },
-    "units": {
+    "spectral_band_units": {
       "type": "string",
       "enum": ["keV", "nm", "MHz"],
       "description": "Units for the spectral data; default unit is keV",


### PR DESCRIPTION
# Description
Correction in reported.schema.
spectral_band, spectral_band_units

