### PR TITLE
Fix spelling error

### DIFF
--- a/gcn/notices/core/Localization.schema.json
+++ b/gcn/notices/core/Localization.schema.json
@@ -58,7 +58,7 @@
       "type": "string",
       "contentEncoding": "base64",
       "contentMediaType": "image/fits",
-      "description": "Base 64 encoded content of a FITS file"
+      "description": "Base64 encoded content of a FITS file"
     }
   }
 }


### PR DESCRIPTION
It's spelled "base64", not "base 64".